### PR TITLE
Changed start up script to also load an optional OpenRGB profile at launch

### DIFF
--- a/startapp.sh
+++ b/startapp.sh
@@ -1,9 +1,8 @@
-#!/bin/sh
-default=$(cat /config/default.txt)
+#!/bin/bash
 
-if [ -z "$default" ]
+if [ -z "${DEFAULT_PROFILE}" ]
 then
 	exec /usr/src/openrgb/OpenRGB
 else
-	exec /usr/src/openrgb/OpenRGB --server --gui --profile $default
+	exec /usr/src/openrgb/OpenRGB --server --gui --profile "${DEFAULT_PROFILE}"
 fi

--- a/startapp.sh
+++ b/startapp.sh
@@ -1,2 +1,9 @@
 #!/bin/sh
-exec /usr/src/openrgb/OpenRGB
+default=$(cat /config/default.txt)
+
+if [ -z "$default" ]
+then
+	exec /usr/src/openrgb/OpenRGB
+else
+	exec /usr/src/openrgb/OpenRGB --server --gui --profile $default
+fi


### PR DESCRIPTION
You will need to create a file called `default.txt` within the appdata or where ever /config is mounted on the host system.
The `default.txt` file contains a path to the .orp file, typically this should be accessible within the Docker container and profiles are usually saved to: `/config/xdg/config/OpenRGB/`